### PR TITLE
Enables VirtualBox basic USB Controller

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
    config.vm.provider "virtualbox" do |vb|
      vb.customize ["modifyvm", :id, "--memory", "4096"]
+     vb.customize ["modifyvm", :id, "--usb", "on"]
    end
 
 


### PR DESCRIPTION
A component of OpenDroneMap software used in the texturing process seems to require a live USB controller or it errors with "failure to load libdc1394". Enabling the basic USB support in VirtualBox fixes the error, USB 2.0 support is not required.
